### PR TITLE
Add typos tool to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,18 @@ repos:
   - id: check-toml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+- repo: https://github.com/crate-ci/typos
+  rev: 6cb49915af2e93e61f5f0d0a82216e28ad5c7c18  # frozen: v1
+  hooks:
+  - id: typos
+    exclude: |
+      (?x)^(
+        .*\.min\.css
+        |.*\.min\.js
+        |.*\.css\.map
+        |.*\.js\.map
+        |.*\.svg
+      )$
 - repo: https://github.com/rstcheck/rstcheck
   rev: f30c4d170a36ea3812bceb5f33004afc213bd797  # frozen: v6.2.4
   hooks:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+# Configuration file for 'typos' tool
+# https://github.com/crate-ci/typos
+
+[default]
+extend-ignore-re = [
+  # Single line ignore comments
+  "(?Rm)^.*(#|//)\\s*typos: ignore$",
+  # Multi-line ignore comments
+  "(?s)(#|//)\\s*typos: off.*?\\n\\s*(#|//)\\s*typos: on"
+]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Changelog
 
 * Unquote table and column names in more cases.
 
-* Handle unparseable SQL statements.
+* Handle unparsable SQL statements.
 
 1.0.0 (2025-04-03)
 ------------------

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ The fingerprinting process applies these changes:
 * Identifier and value lists are reduced to '...'.
 * Identifiers consisting of letters, numbers, and underscores have any quoting removed.
 * Savepoint IDs are replaced with 's1', 's2', etc.
-* Unparseable SQL is returned unchanged.
+* Unparsable SQL is returned unchanged.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use std::ops::ControlFlow;
 
 /// Fingerprint a single SQL string.
 ///
-/// Unparseable SQL is returned as-is.
+/// Unparsable SQL is returned as-is.
 ///
 /// # Example
 /// ```
@@ -30,7 +30,7 @@ pub fn fingerprint_one(input: &str, dialect: Option<&dyn Dialect>) -> String {
 /// Fingerprint multiple SQL strings.
 /// Doing so for a batch of strings allows sharing some state, such as savepoint ID aliases.
 ///
-/// Unparseable SQL is returned as-is.
+/// Unparsable SQL is returned as-is.
 ///
 /// # Example
 /// ```
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unparseable() {
+    fn test_unparsable() {
         let result = fingerprint_many(vec!["SELECT  SELECT  SELECT  SELECT"], None);
         assert_eq!(result, vec!["SELECT  SELECT  SELECT  SELECT"]);
     }


### PR DESCRIPTION
This tool corrects common misspellings in all kinds of text files.
