### PR TITLE
Fix new warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub fn fingerprint_many(input: Vec<&str>, dialect: Option<&dyn Dialect>) -> Vec<
         .map(|sql| match Parser::parse_sql(dialect, sql) {
             Ok(mut ast) => {
                 for stmt in &mut ast {
-                    stmt.visit(&mut savepoint_visitor);
+                    let _ = stmt.visit(&mut savepoint_visitor);
                 }
 
                 ast.into_iter()


### PR DESCRIPTION
Fix:

```
warning: unused `ControlFlow` that must be used
  --> src/lib.rs:52:21
   |
52 |                     stmt.visit(&mut savepoint_visitor);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
52 |                     let _ = stmt.visit(&mut savepoint_visitor);
   |                     +++++++
```
